### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -11,6 +11,8 @@ jobs:
   validation:
     name: "Validation"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: gradle/actions/wrapper-validation@v4


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/NepmodsTester/security/code-scanning/3](https://github.com/FlutterGenerator/NepmodsTester/security/code-scanning/3)

To address this issue, we will add a `permissions` block to the `validation` job to explicitly define the least privileges required for the job to function. Since the `validation` job is primarily validating the Gradle wrapper and does not appear to require write permissions, we will configure the `permissions` block with `contents: read`. This ensures that the job can read the repository contents but cannot perform any write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
