### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -1,5 +1,9 @@
 name: Update Gradle Wrapper
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/NepmodsTester/security/code-scanning/1](https://github.com/FlutterGenerator/NepmodsTester/security/code-scanning/1)

To fix this issue, add an explicit `permissions` block at the workflow level, ensuring the least privileges necessary for the workflow to function correctly. Given the workflow's purpose, it likely requires `contents: read` for repository files and `pull-requests: write` to create or update pull requests. These permissions should be applied either globally to the workflow or specifically to the `update-gradle-wrapper` job.

The fix will involve modifying `.github/workflows/update-gradle-wrapper.yml` to include the `permissions` key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
